### PR TITLE
Write rooms descriptions in run time & Adjust variable name

### DIFF
--- a/NPCs.py
+++ b/NPCs.py
@@ -181,23 +181,23 @@ animal_master_list = [
 ]
 
 
-def gen_character(level):
+def gen_character(level_num):
     """
-    Returns None or a random character object based on the given level number.
+    Returns None or a random character object based on the given level_num number.
     """
     # 50% chance of returning character instead of None
     if randrange(0, 9) >= 5:
 
-        # Later levels can spawn higher index characters
-        if level + 1 > len(character_master_list):     # Prevent index out-of-bounds
+        # Later level_nums can spawn higher index characters
+        if level_num + 1 > len(character_master_list):     # Prevent index out-of-bounds
             range_max = len(character_master_list)
         else:
-            range_max = level + 1
+            range_max = level_num + 1
 
-        if level - 3 < 0:
+        if level_num - 3 < 0:
             range_min = 0
         else:
-            range_min = level - 3
+            range_min = level_num - 3
 
         char_index = randrange(range_min, range_max)
 
@@ -207,23 +207,23 @@ def gen_character(level):
         return None
 
 
-def gen_animal(level):
+def gen_animal(level_num):
     """
-    Returns None or a random animal object based on the given level number.
+    Returns None or a random animal object based on the given level_num number.
     """
     # 50% chance of returning animal instead of None
     if randrange(0, 9) >= 5:
 
-        # Later levels can spawn higher index animals
-        if level + 1> len(animal_master_list):  # Prevent index out-of-bounds
+        # Later level_nums can spawn higher index animals
+        if level_num + 1> len(animal_master_list):  # Prevent index out-of-bounds
             range_max = len(animal_master_list)
         else:
-            range_max = level + 1
+            range_max = level_num + 1
 
-        if level - 2 < 0:
+        if level_num - 2 < 0:
             range_min = 0
         else:
-            range_min = level - 2
+            range_min = level_num - 2
 
         animal_index = randrange(range_min, range_max)
 

--- a/mapGUI.py
+++ b/mapGUI.py
@@ -142,7 +142,6 @@ def display_level(canvas, room, location, x, y, prev_dir=None):
         next_position = nxt_room_position(path, x, y)
         display_level(canvas, room.get_adjacent_room(path), location, 
                       next_position[0], next_position[1], path)
-    return
 
 def start_mini_map_IO(root, location):
     #location is the player's current location (room)
@@ -158,7 +157,6 @@ def start_mini_map_IO(root, location):
         display_room(canvas, location.get_adjacent_room(path), nxt_position[0], 
                      nxt_position[1], False)
     canvas.pack(anchor='sw', side='bottom')
-    return
 
 def start_large_map_IO(level, location):
     #Defines the Enlarged Map Window and Creates the Canvas to generate map

--- a/player.py
+++ b/player.py
@@ -62,14 +62,6 @@ class Player:
         # Print current room's long description
         print(self.location.get_long_desc())
 
-        # If present, print character's description
-        if self.location.get_character() is not None:
-            print(self.location.get_character().get_description())
-
-        # If present, print animal's description.
-        if self.location.get_animal() is not None:
-            print(self.location.get_animal().get_description())
-
     def look(self, dir_str):
 
         # Get the room in the given direction

--- a/room.py
+++ b/room.py
@@ -5,7 +5,16 @@ from mapGUI import *
 
 random.seed()
 
-# FIXME: Room descriptions (short description) needs the landscape description
+# TODO: Room descriptions (short description) needs the landscape description
+
+#changes:
+    # changed the room descriptions such that shrt_desc only gives the landscape 
+    # e.g. 'Dark Forest'. long_desc gives a sentence e.g. 'You are in a Dark 
+    # Forest.' 
+    # However, the functions that return them are different. get_shrt_desc 
+    # returns the short description as is, but get_long_desc returns the room's 
+    # long_desc, the contents' descriptions, and the shrt_desc of the adjacent 
+    # rooms that have been seen.
 
 class Room: 
     

--- a/room.py
+++ b/room.py
@@ -10,7 +10,7 @@ random.seed()
 
 class Room: 
     
-    def __init__(self, level, x=0, y=0, long_desc='Standard Room',
+    def __init__(self, level_num, x=0, y=0, long_desc='Standard Room',
                  shrt_desc='Standard', N=None, S=None, E=None, W=None,
                  item=None):
         """
@@ -38,8 +38,8 @@ class Room:
         self.E = E
         self.W = W
         self.seen = False
-        self.character = gen_character(level)
-        self.animal = gen_animal(level)
+        self.character = gen_character(level_num)
+        self.animal = gen_animal(level_num)
         self.item = item
     
     def apply_position(self, x, y):
@@ -205,12 +205,12 @@ def create_path(level, parent, target, paths):
         return False
 
 
-def gen_random_level(room_num, level):
+def gen_random_level(room_num, level_num):
     # see Concept above for better understanding of function
     all_rooms = []
     avail_rooms = []  # has index of rooms with an available path
     for i in range(0, room_num):
-        all_rooms.append(Room(level))  # create the new room (target)
+        all_rooms.append(Room(level_num))  # create the new room (target)
         avail_rooms.append(i)
         if i == 0:
             continue

--- a/room.py
+++ b/room.py
@@ -5,12 +5,11 @@ from mapGUI import *
 
 random.seed()
 
-
-# FIXME: Change room descriptions according to what the room contains
+# FIXME: Room descriptions (short description) needs the landscape description
 
 class Room: 
     
-    def __init__(self, level_num, x=0, y=0, long_desc='Standard Room',
+    def __init__(self, level_num, x=0, y=0, long_desc='You are in Standard Room',
                  shrt_desc='Standard', N=None, S=None, E=None, W=None,
                  item=None):
         """
@@ -94,7 +93,24 @@ class Room:
     
     def get_long_desc(self):
         # returns the long description of the room
-        return self.long_desc
+        # Print current room's long description
+        
+        desc = self.long_desc + '\n'
+        # If present, print character's description
+        if self.character is not None:
+            desc += self.character.get_description() + '\n'
+        # If present, print animal's description.
+        if self.animal is not None:
+            desc += self.animal.get_description() + '\n'
+        
+        # get seen rooms' short descriptions
+        for path in self.get_existing_paths():
+            adj_room = self.get_adjacent_room(path)
+            if adj_room is not None:
+                if adj_room.get_seen() == True:
+                    desc += 'To the ' + path + ' you see '
+                    desc += adj_room.get_shrt_desc() + '\n'
+        return desc
  
     def get_shrt_desc(self):
         # returns the short description of the room


### PR DESCRIPTION
1. changed variable 'level' used in gen_random_level, Room class, and in NPC functions to 'level_num' to prevent confusion. 'level' is used elsewhere to describe the graph of rooms.

2. changed the room descriptions such that shrt_desc only gives the landscape e.g. 'Dark Forest'. long_desc gives a sentence e.g. 'You are in a Dark Forest.' **However, the functions that return them are different**. get_shrt_desc returns the short description as is, but get_long_desc returns the room's long_desc, the contents' descriptions, and the shrt_desc of the adjacent rooms that have been seen.

_basically does a lot of what @BadScientist suggested._

TODO: set the shrt_desc and long_desc **variables** to show the room landscape