### PR TITLE
keep player start_room far from next_level room

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -419,7 +419,7 @@ def transition_new_level():
         start_room = new_level[randint( 0, level_size[level_idx]-1 )]
         while start_room.get_next_level() == True:
             start_room = new_level[randint( 0, level_size[level_idx]-1 )]
-        player.set_start_position(start_room)
+        player.set_start_position(identify_start_room(cur_level))
     else: #if all levels are complete
         new_level = None
     

--- a/main.py
+++ b/main.py
@@ -8,11 +8,34 @@ from tkinter import *
 from PIL import ImageTk, Image
 import tkinter.font as tkFont
 from PIL import Image, ImageTk
-import os
+import os, math
 
 # Import the Main Menu from interface like a Macro
 from interface import *
+
+def identify_start_room(level):
+    #returns room with greatest distance from nxt_lvl event ie start_room
+    for room in level:
+        if room.get_next_level() == True:
+            nxt_lvl_room = room
+            break
+    nxt_lvl_position = nxt_lvl_room.get_position()
     
+    #use below as standard in case there is only 1 room in level.
+    #otherwise it is bound to change
+    max_distance = 0
+    start_room = nxt_lvl_room 
+    
+    for room in set(level) - {nxt_lvl_room}:
+        room_position = room.get_position()
+        distance = math.hypot(nxt_lvl_position[0]-room_position[0],
+                              nxt_lvl_position[1]-room_position[1])
+        if distance > max_distance:
+            max_distance = distance
+            start_room = room
+    return start_room
+
+
 level_size = [10, 12, 15, 18, 23]
 levels = [
     gen_random_level(level_size[0], 1),
@@ -30,8 +53,9 @@ while start_room.get_next_level():
     start_room = cur_level[randint( 0, level_size[level_idx]-1 )]
 
 player = Player()
-player.set_start_position(start_room)
+player.set_start_position(identify_start_room(cur_level))
 
+identify_start_room(cur_level)
 
 def main():
     print("Crashed")


### PR DESCRIPTION
uses the method @BadScientist suggested in Discord to start the player far away from the next-room event.

Works as far as I have tested it